### PR TITLE
Enable bulk proof generation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,13 @@
-module github.com/Layr-Labs/eigenlayer-rewards-proofs
+module github.com/etherfi-protocol/eigenlayer-rewards-proofs
 
 go 1.21
 
 require (
 	github.com/Layr-Labs/eigenlayer-contracts v0.4.1-holesky-pepe.0.20240813143901-00fc4b95e9c1
+	github.com/Layr-Labs/eigenlayer-rewards-proofs v0.2.13
 	github.com/ethereum/go-ethereum v1.14.0
 	github.com/holiman/uint256 v1.2.4
+	github.com/rs/zerolog v1.33.0
 	github.com/stretchr/testify v1.9.0
 	github.com/wealdtech/go-merkletree/v2 v2.5.2-0.20240302222400-69219c450662
 	github.com/wk8/go-ordered-map/v2 v2.1.8
@@ -35,7 +37,6 @@ require (
 	github.com/mmcloughlin/addchain v0.4.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/rs/zerolog v1.33.0 // indirect
 	github.com/shirou/gopsutil v3.21.4-0.20210419000835-c7a38de76ee5+incompatible // indirect
 	github.com/supranational/blst v0.3.11 // indirect
 	github.com/tklauser/go-sysconf v0.3.12 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,9 @@
 github.com/DataDog/zstd v1.4.5 h1:EndNeuB0l9syBZhut0wns3gV1hL8zX8LIu6ZiVHWLIQ=
 github.com/DataDog/zstd v1.4.5/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
-github.com/Layr-Labs/eigenlayer-contracts v0.3.2-mainnet-rewards h1:G4TH8ZoK7CBybDQAvqkbGqSKCkdA7z5cs9xRqGRzgQE=
-github.com/Layr-Labs/eigenlayer-contracts v0.3.2-mainnet-rewards/go.mod h1:Ie8YE3EQkTHqG6/tnUS0He7/UPMkXPo/3OFXwSy0iRo=
 github.com/Layr-Labs/eigenlayer-contracts v0.4.1-holesky-pepe.0.20240813143901-00fc4b95e9c1 h1:VrPrlQe0T9A74L79FjE1EJkxyIRwKKBoZljwFW/lYWk=
 github.com/Layr-Labs/eigenlayer-contracts v0.4.1-holesky-pepe.0.20240813143901-00fc4b95e9c1/go.mod h1:Ie8YE3EQkTHqG6/tnUS0He7/UPMkXPo/3OFXwSy0iRo=
+github.com/Layr-Labs/eigenlayer-rewards-proofs v0.2.13 h1:Blb4AE+jC/vddV71w4/MQAPooM+8EVqv9w2bL4OytgY=
+github.com/Layr-Labs/eigenlayer-rewards-proofs v0.2.13/go.mod h1:PD/HoyzZjxDw1tAcZw3yD0yGddo+yhmwQAi+lk298r4=
 github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migciow=
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
 github.com/StackExchange/wmi v1.2.1 h1:VIkavFPXSjcnS+O8yTq7NI32k0R5Aj+v39y29VYDOSA=
@@ -118,8 +118,6 @@ github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJ
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
-github.com/mattn/go-isatty v0.0.17 h1:BTarxUcIeDqL27Mc+vyvdWYSL28zpIhv3RoTdsLMPng=
-github.com/mattn/go-isatty v0.0.17/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/mattn/go-isatty v0.0.19 h1:JITubQf0MOLdlGRuRq+jtsDlekdYPia9ZFsB8h/APPA=
 github.com/mattn/go-isatty v0.0.19/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-runewidth v0.0.13 h1:lTGmDsbAYt5DmK6OnoV7EuIF1wEIFAcxld6ypU4OSgU=

--- a/pkg/claimgen/claimgen.go
+++ b/pkg/claimgen/claimgen.go
@@ -146,12 +146,12 @@ func convertTokenLeavesToSolidityLeaves(tokenLeaves []rewardsCoordinator.IReward
 }
 
 type Claimgen struct {
-	distribution *distribution.Distribution
+	Distribution *distribution.Distribution
 }
 
 func NewClaimgen(distro *distribution.Distribution) *Claimgen {
 	return &Claimgen{
-		distribution: distro,
+		Distribution: distro,
 	}
 }
 
@@ -165,7 +165,7 @@ func (c *Claimgen) GenerateClaimProofsForEarners(
 	error,
 ) {
 
-	accountTree, tokenTrees, err := c.distribution.Merklize()
+	accountTree, tokenTrees, err := c.Distribution.Merklize()
 	if err != nil {
 		return nil, nil, err
 	}
@@ -173,7 +173,7 @@ func (c *Claimgen) GenerateClaimProofsForEarners(
 	claims := make([]*rewardsCoordinator.IRewardsCoordinatorRewardsMerkleClaim, len(earners))
 	for idx, earner := range earners {
 		merkleClaim, err := GetProofForEarner(
-			c.distribution,
+			c.Distribution,
 			rootIndex,
 			accountTree,
 			tokenTrees,
@@ -198,13 +198,13 @@ func (c *Claimgen) GenerateClaimProofForEarner(
 	*rewardsCoordinator.IRewardsCoordinatorRewardsMerkleClaim,
 	error,
 ) {
-	accountTree, tokenTrees, err := c.distribution.Merklize()
+	accountTree, tokenTrees, err := c.Distribution.Merklize()
 	if err != nil {
 		return nil, nil, err
 	}
 
 	merkleClaim, err := GetProofForEarner(
-		c.distribution,
+		c.Distribution,
 		rootIndex,
 		accountTree,
 		tokenTrees,

--- a/pkg/claimgen/claimgen.go
+++ b/pkg/claimgen/claimgen.go
@@ -183,7 +183,7 @@ func (c *Claimgen) GenerateClaimProofsForEarners(
 		if err != nil {
 			// if an address does not have a specific token, just skip it instead of failing the whole batch
 			if errors.Is(err, ErrTokenIndexNotFound) {
-				fmt.Printf("earner %s, has not earned specified token, skipping...\n")
+				fmt.Printf("earner %s, has not earned specified token, skipping...\n", earner)
 				continue
 			}
 			return nil, nil, err

--- a/pkg/claimgen/claimgen.go
+++ b/pkg/claimgen/claimgen.go
@@ -182,7 +182,7 @@ func (c *Claimgen) GenerateClaimProofsForEarners(
 		)
 		if err != nil {
 			// if an address does not have a specific token, just skip it instead of failing the whole batch
-			if errors.Is(err, ErrTokenIndexNotFound) {
+			if errors.Is(err, ErrTokenIndexNotFound) || errors.Is(err, ErrEarnerIndexNotFound) {
 				fmt.Printf("earner %s, has not earned specified token, skipping...\n", earner)
 				continue
 			}

--- a/pkg/claimgen/claimgen.go
+++ b/pkg/claimgen/claimgen.go
@@ -170,8 +170,8 @@ func (c *Claimgen) GenerateClaimProofsForEarners(
 		return nil, nil, err
 	}
 
-	claims := make([]*rewardsCoordinator.IRewardsCoordinatorRewardsMerkleClaim, len(earners))
-	for idx, earner := range earners {
+	claims := make([]*rewardsCoordinator.IRewardsCoordinatorRewardsMerkleClaim, 0, len(earners))
+	for _, earner := range earners {
 		merkleClaim, err := GetProofForEarner(
 			c.Distribution,
 			rootIndex,
@@ -181,9 +181,14 @@ func (c *Claimgen) GenerateClaimProofsForEarners(
 			tokens,
 		)
 		if err != nil {
+			// if an address does not have a specific token, just skip it instead of failing the whole batch
+			if errors.Is(err, ErrTokenIndexNotFound) {
+				fmt.Printf("earner %s, has not earned specified token, skipping...\n")
+				continue
+			}
 			return nil, nil, err
 		}
-		claims[idx] = merkleClaim
+		claims = append(claims, merkleClaim)
 	}
 
 	return accountTree, claims, err

--- a/pkg/claimgen/claimgen.go
+++ b/pkg/claimgen/claimgen.go
@@ -155,6 +155,8 @@ func NewClaimgen(distro *distribution.Distribution) *Claimgen {
 	}
 }
 
+// Earners that are skipped due to not being in the tree or not having the required tokens
+// are returned as nil entries in the results and it is up to the caller to filter
 func (c *Claimgen) GenerateClaimProofsForEarners(
 	earners []gethcommon.Address,
 	tokens []gethcommon.Address,
@@ -170,8 +172,8 @@ func (c *Claimgen) GenerateClaimProofsForEarners(
 		return nil, nil, err
 	}
 
-	claims := make([]*rewardsCoordinator.IRewardsCoordinatorRewardsMerkleClaim, 0, len(earners))
-	for _, earner := range earners {
+	claims := make([]*rewardsCoordinator.IRewardsCoordinatorRewardsMerkleClaim, len(earners))
+	for idx, earner := range earners {
 		merkleClaim, err := GetProofForEarner(
 			c.Distribution,
 			rootIndex,
@@ -188,7 +190,7 @@ func (c *Claimgen) GenerateClaimProofsForEarners(
 			}
 			return nil, nil, err
 		}
-		claims = append(claims, merkleClaim)
+		claims[idx] = merkleClaim
 	}
 
 	return accountTree, claims, err

--- a/pkg/claimgen/claimgen_test.go
+++ b/pkg/claimgen/claimgen_test.go
@@ -1,11 +1,12 @@
 package claimgen
 
 import (
+	"testing"
+
 	"github.com/Layr-Labs/eigenlayer-rewards-proofs/internal/tests"
 	"github.com/Layr-Labs/eigenlayer-rewards-proofs/pkg/distribution"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestNewClaimgen(t *testing.T) {
@@ -14,7 +15,7 @@ func TestNewClaimgen(t *testing.T) {
 	cg := NewClaimgen(distro)
 
 	assert.NotNil(t, cg)
-	assert.NotNil(t, cg.distribution)
+	assert.NotNil(t, cg.Distribution)
 }
 
 func TestGetProofForEarner(t *testing.T) {


### PR DESCRIPTION
The existing eigenlayer implementation re merkleizes the distribution data for every claim which is extremely slow for generating bulk proofs. This adds new methods to support efficient bulk operations